### PR TITLE
fix job import

### DIFF
--- a/developers/jobs/create.adoc
+++ b/developers/jobs/create.adoc
@@ -15,7 +15,7 @@ Then, open the file and place a PHP class within this file that matches the name
 
 namespace Application\Job;
 
-use Concrete\Job\Job as AbstractJob;
+use Concrete\Core\Job\Job as AbstractJob;
 
 class SummarizeStatistics extends AbstractJob
 {


### PR DESCRIPTION
This example didn't work, had to change the namespace, see http://concrete5.org/api/class-Concrete.Core.Job.Job.html